### PR TITLE
Add timing

### DIFF
--- a/src/hooks/useGame.test.tsx
+++ b/src/hooks/useGame.test.tsx
@@ -75,6 +75,8 @@ describe('useGame hook', () => {
         await waitFor(() => ref.current.outcome !== null, 4000)
         expect(ref.current.outcome?.type).toBe('win')
         expect(ref.current.outcome?.answer).toBe('alpha')
+        expect(typeof ref.current.outcome?.durationMs).toBe('number')
+        expect(ref.current.outcome?.durationMs).toBeGreaterThanOrEqual(0)
         const stats = getStats()
         expect(stats.freeplay.wins).toBe(1)
         expect(stats.freeplay.gamesPlayed).toBe(1)

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -8,6 +8,8 @@
   "backspace": "Backspace",
   "win": "You win! 🎉",
   "lose": "Sorry. The word was: {{word}}",
+  "winTimed": "You win in {{seconds}}s! 🎉",
+  "loseTimed": "Sorry ({{seconds}}s). The word was: {{word}}",
   "wordlistLink": "Wordlist & Attribution",
   "home": "Home",
   "about": "About",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -8,6 +8,8 @@
   "backspace": "Backspace",
   "win": "Gewonnen! 🎉",
   "lose": "Helaas. Het woord was: {{word}}",
+  "winTimed": "Gewonnen in {{seconds}}s! 🎉",
+  "loseTimed": "Helaas ({{seconds}}s). Het woord was: {{word}}",
   "wordlistLink": "Woordenlijst & Vermelding",
   "home": "Start",
   "about": "Over",

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -22,6 +22,8 @@ export type DailyProgress = {
     guesses: string[];  // submitted guesses
     board: { ch: string; state: string }[][];
     keyboard: Record<string, string>;
+    startedAt?: number; // epoch ms when this daily game started
+    finishedAt?: number; // epoch ms when completed
 };
 
 export type FreeplayProgress = {
@@ -29,6 +31,8 @@ export type FreeplayProgress = {
     guesses: string[];
     board: { ch: string; state: string }[][];
     keyboard: Record<string, string>;
+    startedAt?: number;
+    finishedAt?: number;
 }
 
 // -------------------------------

--- a/src/screens/App.tsx
+++ b/src/screens/App.tsx
@@ -21,11 +21,15 @@ export default function App() {
         return () => window.removeEventListener('keydown', onKey);
     }, [handleKey]);
 
-    // Outcome alerts
+    // Outcome alerts (with timing)
     useEffect(() => {
         if (!outcome) return;
-        if (outcome.type === 'win') alert(t('win'))
-        else alert(t('lose', {word: outcome.answer}));
+        const seconds = (outcome.durationMs / 1000).toFixed(1);
+        if (outcome.type === 'win') {
+            alert(t('winTimed', {seconds}));
+        } else {
+            alert(t('loseTimed', {word: outcome.answer, seconds}));
+        }
         acknowledgeOutcome();
     }, [acknowledgeOutcome, outcome, t]);
 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -3,5 +3,5 @@ export type KeyState = 'correct' | 'present' | 'absent' | undefined;
 export type LetterState = 'correct' | 'present' | 'absent' | 'empty';
 export type Cell = { ch: string; state: TileState };
 export type EvalResult = { states: LetterState[] };
-export type Outcome = { type: 'win' | 'lose'; answer: string; } | null;
+export type Outcome = { type: 'win' | 'lose'; answer: string; durationMs: number; } | null;
 export type GameMode = 'daily' | 'freeplay';


### PR DESCRIPTION
This pull request enhances the game tracking and user feedback by adding timing information to game sessions. Now, the start and end times of each game are recorded, and the duration is displayed in the win/lose alerts. The changes span the game logic, persistent storage, types, and UI messaging.

**Game timing and persistence improvements:**

* Added `startedAt` and `finishedAt` timestamps to both `DailyProgress` and `FreeplayProgress` in `src/lib/storage.ts`, enabling precise tracking of when games start and finish.
* Updated the `useGame` hook in `src/hooks/useGame.ts` to initialize and persist `startedAt` when a game begins, and to persist `finishedAt` when a game ends. The outcome object now includes `durationMs`, representing the time taken to complete the game. [[1]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dR40) [[2]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dR72-R87) [[3]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dR96-R113) [[4]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dL123-R214) [[5]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dR231-R246) [[6]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dL180-R260)

**Type and test updates:**

* Extended the `Outcome` type in `src/types/game.ts` to include a `durationMs` field, and updated tests in `src/hooks/useGame.test.tsx` to verify the presence and correctness of this new field. [[1]](diffhunk://#diff-c36fbf336707574386e8ac258eca2c397b4b85a51a1ffc66865ab3a84f3f083cL6-R6) [[2]](diffhunk://#diff-b8548e34b15f9e4142126f429dda5dce0cb0b8bbf45006b5ab1a0ff87863346bR78-R79)

**User interface and localization:**

* Modified the outcome alert in `src/screens/App.tsx` to display the time taken in seconds, using new localized strings.
* Added `winTimed` and `loseTimed` translations to English and Dutch locale files for improved user feedback. [[1]](diffhunk://#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0R11-R12) [[2]](diffhunk://#diff-a0823e318a3294180c37658bb6c26c4090bbf521493cfaf8622db1eae716059cR11-R12)