### PR TITLE
fix game

### DIFF
--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -29,11 +29,11 @@ function reconstructBoard(wordLen: number, guesses: string[], answer: string): C
     for (let i = 0; i < guesses.length && i < MAX_ATTEMPTS; i++) {
         const g = guesses[i]
         const res = evaluateGuess(g, answer)
-        board.push(g.split('').map((ch, idx) => ({ch, state: res.states[idx] as TileState})))
+        board.push(g.split('').map((ch, idx) => ({ch, state: (res.states[idx] as TileState) || 'empty'})))
     }
     // Fill remaining rows
     while (board.length < MAX_ATTEMPTS) {
-        board.push(Array.from({length: wordLen}, () => ({ch: '', state: 'empty' as TileState})))
+        board.push(makeEmptyRow(wordLen))
     }
     return board
 }

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -38,6 +38,10 @@ function reconstructBoard(wordLen: number, guesses: string[], answer: string): C
     return board
 }
 
+function makeEmptyRow(len: number): Cell[] {
+    return Array.from({length: len}, () => ({ch: '', state: 'empty' as TileState}))
+}
+
 export function useGame(lang: string, mode: GameMode = 'daily') {
     const [ready, setReady] = useState(false)
     const [allowed, setAllowed] = useState<number[]>([])


### PR DESCRIPTION
This pull request improves how the game board state is initialized, saved, and restored for both daily and freeplay game modes. The main focus is to ensure that the board is always correctly reconstructed from guesses if needed, and that new games properly initialize and persist the board state. The changes also refactor helper functions to make board creation more consistent.

**State Initialization and Migration Improvements:**

* Added a new `reconstructBoard` function to rebuild the board from guesses and the answer, which is used to migrate old progress data that lacks a board state.
* Updated the logic for resuming games (both daily and freeplay) to use `reconstructBoard` if the stored board is empty, ensuring compatibility with previous save formats. [[1]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dL70-R103) [[2]](diffhunk://#diff-f43b3946da7a641162dc66e5c49456976f5f3dbe68b93ba3dbadd24e750d1c2dR112-R134)

**Consistent Board Creation and Persistence:**

* Refactored the `freshBoard` helper to return the created board and set rows in a single step, ensuring the board is always available for persistence.
* Updated all new game initialization code to use the returned board from `freshBoard` and persist it immediately, instead of initializing with an empty array.